### PR TITLE
Remove Quotes from Description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+v 1.0.2
+
+- Changelog added
+- Quotation marks are now removed from the description in base class ZCL_CDS_ALV_BASE. This fixes an issue with incorrect syntax being generated for CDS view entities.
+
+v 1.0.1
+
+- Master Language changed from German (DE) to English (EN)
+- Version added (version is now 1.0.1)

--- a/src/zcl_cds_alv_base.clas.abap
+++ b/src/zcl_cds_alv_base.clas.abap
@@ -58,7 +58,7 @@ CLASS ZCL_CDS_ALV_BASE IMPLEMENTATION.
                                                          e_parameter_annotations = parameter_annotations ).
 
     TRY.
-        description = entity_annotations[ annoname = 'ENDUSERTEXT.LABEL' ]-value.
+        description = remove_quotes( entity_annotations[ annoname = 'ENDUSERTEXT.LABEL' ]-value ).
       CATCH cx_sy_itab_line_not_found.
         description = cds_view.
     ENDTRY.


### PR DESCRIPTION
Remove quotes from the description in the base class.
This fixes an error we encountered on newer releases where the generated reports for view entities had syntax errors